### PR TITLE
fix bug: NullPointerException in SettingsActivity due to getCurrentFocus().clearFocus()

### DIFF
--- a/app/src/main/java/eu/quelltext/mundraub/activities/SettingsActivity.java
+++ b/app/src/main/java/eu/quelltext/mundraub/activities/SettingsActivity.java
@@ -408,7 +408,10 @@ public class SettingsActivity extends MundraubBaseActivity {
 
     @Override
     protected void onPause() {
-        getCurrentFocus().clearFocus(); // commit the text fields if focused
+        View current = getCurrentFocus();
+        if (current != null) {
+            current.clearFocus(); // commit the text fields if focused
+        }
         super.onPause();
         plantProgressAutoUpdate.stop();
         mapProgressAutoUpdate.stop();


### PR DESCRIPTION
Fixed NullPointerException in SettingsActivity caused by getCurrentFocus().clearFocus() (onPause()) by checking if the current focus is null before clearing focus
Fixes https://github.com/niccokunzmann/mundraub-android/issues/304